### PR TITLE
Close open beta applications; add waitlist and delay notice

### DIFF
--- a/index.html
+++ b/index.html
@@ -1374,7 +1374,7 @@ footer::before{content:'';position:absolute;top:0;left:30%;right:30%;height:1px;
     <div class="how-intro" data-r>
       <p class="label">Setup</p>
       <h2 class="title">Running in three steps.<br><em>No terminal required.</em></h2>
-      <p class="beta-tag" role="status"><span class="beta-tag-dot" aria-hidden="true"></span>Private beta &middot; installer ships to approved testers</p>
+      <p class="beta-tag" role="status"><span class="beta-tag-dot" aria-hidden="true"></span>Private beta &middot; open applications closed &middot; installer ships to approved testers</p>
     </div>
     <div class="steps">
       <div class="stp" data-r data-d="100">
@@ -1504,17 +1504,17 @@ footer::before{content:'';position:absolute;top:0;left:30%;right:30%;height:1px;
           </div>
           <div class="price-card price-card--beta">
             <div class="price-name">Beta Tester Access</div>
-            <div class="price-amt">$0</div>
-            <div class="price-per">/ limited beta</div>
+            <div class="price-amt">Closed</div>
+            <div class="price-per">/ applications paused</div>
             <ul class="price-list">
-              <li>Early access to new builds</li>
-              <li>Direct feedback channel to the team</li>
-              <li>Influence roadmap priorities</li>
-              <li>Help shape onboarding and workflows</li>
+              <li>Open applications closed earlier in July 2026</li>
+              <li>Current testers keep full access</li>
+              <li>Join the waitlist for the next cohort</li>
+              <li>We&rsquo;ll email you when applications reopen</li>
             </ul>
-            <a class="price-btn" href="mailto:kennedyappliedsciences@gmail.com?subject=StratoSort%20Beta%20Tester%20Request">Become a beta tester</a>
+            <a class="price-btn" href="mailto:kennedyappliedsciences@gmail.com?subject=StratoSort%20Beta%20Waitlist&amp;body=Hi%20%E2%80%94%20please%20add%20me%20to%20the%20StratoSort%20beta%20waitlist.%0A%0ARole%3A%0APlatform%20(Windows%2FmacOS%2FLinux)%3A%0ATop%20use%20case%3A%0A">Join the waitlist</a>
             <div class="price-context">
-              <p>Click to email the team and request access. Include your role, platform, and top use case.</p>
+              <p>Open beta applications closed earlier this month. This page was updated to reflect that later than intended &mdash; the delay was an accidental oversight, not a change in the program. Join the waitlist and we&rsquo;ll notify you when the next cohort opens.</p>
             </div>
           </div>
       </div>


### PR DESCRIPTION
## Summary

Open beta applications stopped earlier this month, but the site still invited new applicants. This updates the site to reflect that the program's open-application window is closed and points visitors to a waitlist instead.

## Changes (`index.html`)

- **Setup section tag** — now reads "Private beta · **open applications closed** · installer ships to approved testers".
- **Beta Tester Access card** — converted from an open application CTA into a closed/waitlist state:
  - Amount reads **"Closed / applications paused"**.
  - List updated: applications closed earlier in July 2026, current testers keep full access, join the waitlist for the next cohort.
  - Button changed from "Become a beta tester" → **"Join the waitlist"** (pre-filled waitlist email).
  - Added a short visitor-facing notice that applications closed earlier this month and the page was updated late due to an accidental oversight.

## Context

The site detail lagged the actual program status because the update to reflect the closure was delayed accidentally. Automated systems should have triggered a code review before that point, but this did not occur.

## Freshness review

Checked the rest of the site for staleness — copyright year (dynamic, 2026), pricing ($99, consistent with JSON-LD structured data), email CTAs, and the privacy/terms beta-program descriptions (still accurate — the program exists, only applications are paused). No other changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C9mtN5UH5i2y1t84CHaLLC)_